### PR TITLE
Add docker-based stack script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # Coaching Backend
 
-Start MySQL:
+Start the entire stack with Docker Compose:
+
+```
+./start.sh
+```
+
+If you prefer to run the backend manually, start only the database first:
 
 ```
 docker-compose up -d db
 ```
 
-Run the server:
+Then run the server locally:
 
 ```
 go run ./backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o /out/app
+
+FROM alpine
+WORKDIR /app
+RUN apk add --no-cache ca-certificates
+COPY --from=build /out/app ./app
+ENV DB_DSN=root:password@tcp(db:3306)/coaching?charset=utf8mb4&parseTime=True&loc=Local
+EXPOSE 8080
+CMD ["./app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,22 @@ services:
       - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
+
+  backend:
+    build: ./backend
+    environment:
+      DB_DSN: root:password@tcp(db:3306)/coaching?charset=utf8mb4&parseTime=True&loc=Local
+    depends_on:
+      - db
+    ports:
+      - "8080:8080"
+
+  frontend:
+    build: ./frontend
+    depends_on:
+      - backend
+    ports:
+      - "5173:5173"
+
 volumes:
   db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm","run","dev","--","--host","0.0.0.0"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+docker compose up -d --build


### PR DESCRIPTION
## Summary
- add Dockerfiles for backend and frontend
- extend docker-compose to run backend, frontend, and db
- provide `start.sh` script to boot the full stack
- update README instructions

## Testing
- `go test ./...` *(fails: process hangs)*
- `npm test --silent` in frontend *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845357a54a0832b82241b5b188be2f6