### PR TITLE
Add header logo

### DIFF
--- a/frontend/public/logo-app.png
+++ b/frontend/public/logo-app.png
@@ -1,0 +1,1 @@
+../../logo-app.png

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -9,6 +9,11 @@
   padding: 1rem;
 }
 
+.header-logo {
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
 .app-header ul {
   list-style: none;
   padding: 0;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,6 +4,7 @@ import './Header.css'
 export default function Header() {
   return (
     <header className="app-header">
+      <img src="/logo-app.png" alt="logo" className="header-logo" />
       <nav>
         <ul>
           <li><Link to="/add-member">Add Member</Link></li>


### PR DESCRIPTION
## Summary
- show logo image at the top of Header
- style header logo
- make logo available in frontend public folder as symlink

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684542cde084832b8bd7ca3fdf2097e6