### PR TITLE
Persist MySQL data locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ replay_pid*
 
 # backend binary
 backend/app
+# local MySQL data directory
+mysql_data/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Start the entire stack with Docker Compose:
 ./start.sh
 ```
 
+The MySQL container stores its data in the `mysql_data` directory so it
+persists across restarts. This folder is ignored by git.
+
 If you prefer to run the backend manually, start only the database first:
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - db_data:/var/lib/mysql
+      - ./mysql_data:/var/lib/mysql
 
   backend:
     build: ./backend
@@ -26,5 +26,3 @@ services:
     ports:
       - "5173:5173"
 
-volumes:
-  db_data:


### PR DESCRIPTION
## Summary
- persist the MySQL container data in `mysql_data`
- ignore the local DB folder in git
- document DB persistence in README

## Testing
- `go test ./...` *(fails: directory prefix '.' does not contain main module or its selected dependencies; then interrupted)*

## Prompt

```
Improve experience dev: Ensure the MySQL database is mapped to a local directory 
(also add this local directory to the .gitignore) so I don't lose the database every time I restart the app.
```

------
https://chatgpt.com/codex/tasks/task_e_6845ea0f8adc832bbc83e01c0d58d647