### PR TITLE
Add toast notifications on save

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import FeedbackPage from './pages/FeedbackPage'
 import TeamList from './pages/TeamList'
 import ViewFeedback from './pages/ViewFeedback'
 import Header from './components/Header'
+import Toast from './components/Toast'
 import './App.css'
 
 type Member = { name: string; email: string; picture: string }
@@ -16,6 +17,12 @@ export default function App() {
   const [members, setMembers] = useState<Member[]>([])
   const [teams, setTeams] = useState<Team[]>([])
   const [feedbacks, setFeedbacks] = useState<{ target: string; message: string }[]>([])
+  const [toast, setToast] = useState('')
+
+  const showToast = (msg: string) => {
+    setToast(msg)
+    setTimeout(() => setToast(''), 5000)
+  }
 
   const addMember = (m: Member) => setMembers([...members, m])
   const addTeam = (t: { name: string; logo: string }) =>
@@ -44,13 +51,14 @@ export default function App() {
   return (
     <div className="app-container">
       <Header />
+      <Toast message={toast} />
       <div className="app-content">
         <Routes>
-          <Route path="/add-member" element={<AddMember onAdd={addMember} />} />
-          <Route path="/create-team" element={<CreateTeam onAdd={addTeam} />} />
+          <Route path="/add-member" element={<AddMember onAdd={addMember} onSuccess={() => showToast('Success')} />} />
+          <Route path="/create-team" element={<CreateTeam onAdd={addTeam} onSuccess={() => showToast('Success')} />} />
           <Route
             path="/assign-team"
-            element={<AssignTeam members={memberNames} teams={teamNames} onAssign={assign} />}
+            element={<AssignTeam members={memberNames} teams={teamNames} onAssign={assign} onSuccess={() => showToast('Success')} />}
           />
           <Route
             path="/teams"
@@ -58,13 +66,13 @@ export default function App() {
           />
           <Route
             path="/feedback"
-            element={<FeedbackPage members={memberNames} teams={teamNames} onSubmit={feedback} />}
+            element={<FeedbackPage members={memberNames} teams={teamNames} onSubmit={feedback} onSuccess={() => showToast('Success')} />}
           />
           <Route
             path="/view-feedback"
             element={<ViewFeedback members={memberNames} feedbacks={feedbacks} />}
           />
-          <Route path="*" element={<AddMember onAdd={addMember} />} />
+          <Route path="*" element={<AddMember onAdd={addMember} onSuccess={() => showToast('Success')} />} />
         </Routes>
       </div>
     </div>

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function Toast({ message }: { message: string }) {
+  if (!message) return null
+  return (
+    <div className="toast">
+      {message}
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -91,3 +91,14 @@ textarea {
   border-radius: 4px;
   border: 1px solid #ccc;
 }
+
+.toast {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background-color: #333;
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  z-index: 1000;
+}

--- a/frontend/src/pages/AddMember.tsx
+++ b/frontend/src/pages/AddMember.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import InputField from '../components/InputField'
 import { API_URL } from '../api'
 
-export default function AddMember({ onAdd }: { onAdd: (m: { name: string; email: string; picture: string }) => void }) {
+export default function AddMember({ onAdd, onSuccess }: { onAdd: (m: { name: string; email: string; picture: string }) => void; onSuccess?: () => void }) {
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')
   const [picture, setPicture] = useState('')
@@ -15,6 +15,7 @@ export default function AddMember({ onAdd }: { onAdd: (m: { name: string; email:
       body: JSON.stringify(payload),
     }).catch(console.error)
     onAdd(payload)
+    onSuccess && onSuccess()
     setName('')
     setEmail('')
     setPicture('')

--- a/frontend/src/pages/AssignTeam.tsx
+++ b/frontend/src/pages/AssignTeam.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { API_URL } from '../api'
 
-export default function AssignTeam({ members, teams, onAssign }: { members: string[]; teams: string[]; onAssign: (m: string, t: string) => void }) {
+export default function AssignTeam({ members, teams, onAssign, onSuccess }: { members: string[]; teams: string[]; onAssign: (m: string, t: string) => void; onSuccess?: () => void }) {
   const [member, setMember] = useState(members[0] || '')
   const [team, setTeam] = useState(teams[0] || '')
   const submit = async (e: React.FormEvent) => {
@@ -14,6 +14,7 @@ export default function AssignTeam({ members, teams, onAssign }: { members: stri
         body: JSON.stringify(payload),
       }).catch(console.error)
       onAssign(member, team)
+      onSuccess && onSuccess()
     }
   }
   return (

--- a/frontend/src/pages/CreateTeam.tsx
+++ b/frontend/src/pages/CreateTeam.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import InputField from '../components/InputField'
 import { API_URL } from '../api'
 
-export default function CreateTeam({ onAdd }: { onAdd: (t: { name: string; logo: string }) => void }) {
+export default function CreateTeam({ onAdd, onSuccess }: { onAdd: (t: { name: string; logo: string }) => void; onSuccess?: () => void }) {
   const [name, setName] = useState('')
   const [logo, setLogo] = useState('')
   const submit = async (e: React.FormEvent) => {
@@ -14,6 +14,7 @@ export default function CreateTeam({ onAdd }: { onAdd: (t: { name: string; logo:
       body: JSON.stringify(payload),
     }).catch(console.error)
     onAdd(payload)
+    onSuccess && onSuccess()
     setName('')
     setLogo('')
   }

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { API_URL } from '../api'
 
-export default function FeedbackPage({ members, teams, onSubmit }: { members: string[]; teams: string[]; onSubmit: (target: string, message: string) => void }) {
+export default function FeedbackPage({ members, teams, onSubmit, onSuccess }: { members: string[]; teams: string[]; onSubmit: (target: string, message: string) => void; onSuccess?: () => void }) {
   const [target, setTarget] = useState('')
   const [message, setMessage] = useState('')
   const options = [...members, ...teams]
@@ -15,6 +15,7 @@ export default function FeedbackPage({ members, teams, onSubmit }: { members: st
         body: JSON.stringify(payload),
       }).catch(console.error)
       onSubmit(target, message)
+      onSuccess && onSuccess()
       setMessage('')
     }
   }


### PR DESCRIPTION
## Summary
- notify users on successful saves with a toast message
- wire toast notifications to AddMember, CreateTeam, AssignTeam and FeedbackPage
- add toast styles

## Testing
- `npm test --silent`
- `go test ./...`

## Prompt

``
improve frontend experince: for all pages, when some record is saved like when we give feedback or when we create a team or when we add a member or when we asign a member to a team I would like to see a TOST on the UI(not an alert) for 5s saying "sucess".
``


------
https://chatgpt.com/codex/tasks/task_e_6845f99185b4832b8684a7aae98745c1