### PR TITLE
Fix frontend data loading

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Route, Routes } from 'react-router-dom'
 import AddMember from './pages/AddMember'
 import CreateTeam from './pages/CreateTeam'
@@ -9,6 +9,7 @@ import ViewFeedback from './pages/ViewFeedback'
 import Header from './components/Header'
 import Toast from './components/Toast'
 import './App.css'
+import { API_URL } from './api'
 
 type Member = { name: string; email: string; picture: string }
 type Team = { name: string; logo: string; members: string[] }
@@ -23,6 +24,56 @@ export default function App() {
     setToast(msg)
     setTimeout(() => setToast(''), 5000)
   }
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const mRes = await fetch(`${API_URL}/members`)
+        let memberMap: Record<number, string> = {}
+        if (mRes.ok) {
+          const ms = await mRes.json()
+          setMembers(ms.map((m: any) => {
+            memberMap[m.ID] = m.Name
+            return {
+              name: m.Name,
+              email: m.Email,
+              picture: m.Picture,
+            }
+          }))
+        }
+
+        const tRes = await fetch(`${API_URL}/team-members`)
+        let teamMap: Record<number, string> = {}
+        if (tRes.ok) {
+          const ts = await tRes.json()
+          const teams = ts.map((t: any) => {
+            teamMap[t.Team.ID] = t.Team.Name
+            t.Members.forEach((m: any) => {
+              memberMap[m.ID] = m.Name
+            })
+            return {
+              name: t.Team.Name,
+              logo: t.Team.Logo,
+              members: t.Members.map((m: any) => m.Name),
+            }
+          })
+          setTeams(teams)
+        }
+
+        const fRes = await fetch(`${API_URL}/feedbacks`)
+        if (fRes.ok) {
+          const fs = await fRes.json()
+          setFeedbacks(fs.map((f: any) => ({
+            target: memberMap[f.MemberID] || teamMap[f.TeamID] || '',
+            message: f.Content,
+          })))
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    }
+    load()
+  }, [])
 
   const addMember = (m: Member) => setMembers([...members, m])
   const addTeam = (t: { name: string; logo: string }) =>

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,1 +1,6 @@
 import '@testing-library/jest-dom'
+
+// Mock global fetch for components that make network calls during tests
+globalThis.fetch = vi.fn(() =>
+  Promise.resolve({ ok: true, json: async () => [] }) as any
+)


### PR DESCRIPTION
## Summary
- fetch members, teams, and feedbacks from the API on startup
- mock global `fetch` in tests so they do not hit a real server

## Testing
- `npm test`

## Prompt

``
there is a bug on the frontend that is not loading existing data from the db:

http://localhost:8080/members (has data)

[
  {
    "ID": 1,
    "CreatedAt": "2025-06-08T20:55:33.228Z",
    "UpdatedAt": "2025-06-08T20:55:33.228Z",
    "DeletedAt": null,
    "Name": "Diego",
    "Picture": "diego.png",
    "Email": "diego@gmail.com"
  },
  {
    "ID": 2,
    "CreatedAt": "2025-06-08T20:55:44.667Z",
    "UpdatedAt": "2025-06-08T20:55:44.667Z",
    "DeletedAt": null,
    "Name": "Gandolfy",
    "Picture": "gando.png",
    "Email": "gandolfy@gmail.com"
  }
]

and frontend does not show - this is happening to all pages - fix it
``

------
https://chatgpt.com/codex/tasks/task_e_6845fbbf3104832bab5ff76fe946b7db