### PR TITLE
Fix assignments and feedback persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ API endpoints:
 - `POST /teams`
 - `GET /teams`
 - `POST /assignments`
+- `GET /assignments`
 - `POST /feedbacks`
 - `GET /feedbacks`
 


### PR DESCRIPTION
## Summary
- support posting assignments by name or ID and expose `GET /assignments`
- fix feedback posting to accept target names
- add tests for assignments endpoint and use isolated sqlite DB
- document new API endpoint

## Testing
- `go test ./...`
- `npm test --silent`

## Pompt

``
fix another bug:

backend need expose an endpoint GET /assignments and frontend needs fix the /teams page which is load loading the member of the teams properly/. 

the next bug is on give feedback and list feedback:

the data is not going to the backend or the backend is wrong so when I list feedback I dont see it (after restart the app)
``

------
https://chatgpt.com/codex/tasks/task_e_6845ff522618832b8759f0cbec0a7800