### PR TITLE
Add frontend tests

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,10 +29,10 @@ export default function App() {
     const load = async () => {
       try {
         const mRes = await fetch(`${API_URL}/members`)
-        let memberMap: Record<number, string> = {}
+        const memberMap: Record<number, string> = {}
         if (mRes.ok) {
-          const ms = await mRes.json()
-          setMembers(ms.map((m: any) => {
+          const ms: { ID: number; Name: string; Email: string; Picture: string }[] = await mRes.json()
+          setMembers(ms.map(m => {
             memberMap[m.ID] = m.Name
             return {
               name: m.Name,
@@ -43,18 +43,18 @@ export default function App() {
         }
 
         const tRes = await fetch(`${API_URL}/team-members`)
-        let teamMap: Record<number, string> = {}
+        const teamMap: Record<number, string> = {}
         if (tRes.ok) {
-          const ts = await tRes.json()
-          const teams = ts.map((t: any) => {
+          const ts: { Team: { ID: number; Name: string; Logo: string }; Members: { ID: number; Name: string }[] }[] = await tRes.json()
+          const teams = ts.map(t => {
             teamMap[t.Team.ID] = t.Team.Name
-            t.Members.forEach((m: any) => {
+            t.Members.forEach(m => {
               memberMap[m.ID] = m.Name
             })
             return {
               name: t.Team.Name,
               logo: t.Team.Logo,
-              members: t.Members.map((m: any) => m.Name),
+              members: t.Members.map(m => m.Name),
             }
           })
           setTeams(teams)
@@ -62,8 +62,8 @@ export default function App() {
 
         const fRes = await fetch(`${API_URL}/feedbacks`)
         if (fRes.ok) {
-          const fs = await fRes.json()
-          setFeedbacks(fs.map((f: any) => ({
+          const fs: { MemberID: number; TeamID: number; Content: string }[] = await fRes.json()
+          setFeedbacks(fs.map(f => ({
             target: memberMap[f.MemberID] || teamMap[f.TeamID] || '',
             message: f.Content,
           })))

--- a/frontend/src/pages/AddMember.tsx
+++ b/frontend/src/pages/AddMember.tsx
@@ -15,7 +15,7 @@ export default function AddMember({ onAdd, onSuccess }: { onAdd: (m: { name: str
       body: JSON.stringify(payload),
     }).catch(console.error)
     onAdd(payload)
-    onSuccess && onSuccess()
+    if (onSuccess) onSuccess()
     setName('')
     setEmail('')
     setPicture('')

--- a/frontend/src/pages/AssignTeam.tsx
+++ b/frontend/src/pages/AssignTeam.tsx
@@ -14,7 +14,7 @@ export default function AssignTeam({ members, teams, onAssign, onSuccess }: { me
         body: JSON.stringify(payload),
       }).catch(console.error)
       onAssign(member, team)
-      onSuccess && onSuccess()
+      if (onSuccess) onSuccess()
     }
   }
   return (

--- a/frontend/src/pages/CreateTeam.tsx
+++ b/frontend/src/pages/CreateTeam.tsx
@@ -14,7 +14,7 @@ export default function CreateTeam({ onAdd, onSuccess }: { onAdd: (t: { name: st
       body: JSON.stringify(payload),
     }).catch(console.error)
     onAdd(payload)
-    onSuccess && onSuccess()
+    if (onSuccess) onSuccess()
     setName('')
     setLogo('')
   }

--- a/frontend/src/pages/FeedbackPage.tsx
+++ b/frontend/src/pages/FeedbackPage.tsx
@@ -15,7 +15,7 @@ export default function FeedbackPage({ members, teams, onSubmit, onSuccess }: { 
         body: JSON.stringify(payload),
       }).catch(console.error)
       onSubmit(target, message)
-      onSuccess && onSuccess()
+      if (onSuccess) onSuccess()
       setMessage('')
     }
   }

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom'
 
-// Mock global fetch for components that make network calls during tests
 globalThis.fetch = vi.fn(() =>
-  Promise.resolve({ ok: true, json: async () => [] }) as any
+  Promise.resolve({ ok: true, json: async () => [] }) as unknown as Response
 )

--- a/frontend/tests/InputField.test.tsx
+++ b/frontend/tests/InputField.test.tsx
@@ -10,3 +10,11 @@ it('calls onChange when typing', () => {
   fireEvent.change(input, { target: { value: 'John' } })
   expect(handle).toHaveBeenCalledWith('John')
 })
+
+it('renders type and placeholder', () => {
+  const { getByPlaceholderText } = render(
+    <InputField value="" onChange={() => {}} placeholder="Email" type="email" />
+  )
+  const input = getByPlaceholderText('Email') as HTMLInputElement
+  expect(input.type).toBe('email')
+})

--- a/frontend/tests/Toast.test.tsx
+++ b/frontend/tests/Toast.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react'
+import Toast from '../src/components/Toast'
+
+it('renders message', () => {
+  const { getByText } = render(<Toast message="Hi" />)
+  expect(getByText('Hi')).toBeInTheDocument()
+})
+
+it('returns null when empty', () => {
+  const { container } = render(<Toast message="" />)
+  expect(container.firstChild).toBeNull()
+})


### PR DESCRIPTION
## Summary
- extend InputField tests and add new tests for Toast
- fix lint issues across frontend code

## Prompt
add more tests to the frontend

## Test Output
```
 RUN  v3.2.2 /workspace/codex-poc/frontend
 ✓ tests/CreateTeam.test.tsx (1 test) 76ms
 ✓ tests/AssignTeam.test.tsx (1 test) 151ms
 ✓ tests/FeedbackPage.test.tsx (1 test) 183ms
 ✓ tests/ViewFeedback.test.tsx (1 test) 126ms
 ✓ tests/AddMember.test.tsx (1 test) 73ms
 ✓ tests/App.test.tsx (1 test) 103ms
 ✓ tests/TeamList.test.tsx (1 test) 67ms
 ✓ tests/InputField.test.tsx (2 tests) 60ms
 ✓ tests/Toast.test.tsx (2 tests) 149ms

 Test Files  9 passed (9)
      Tests  11 passed (11)
   Start at  02:52:43
   Duration  5.43s (transform 1.13s, setup 1.49s, collect 3.72s, tests 989ms, environment 5.23s, prepare 1.13s)
```


------
https://chatgpt.com/codex/tasks/task_e_68479b50dba4832b8cb01ab24825049c