### PR TITLE
Fix setupTests import

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom'
+import { vi } from 'vitest'
 
 globalThis.fetch = vi.fn(() =>
   Promise.resolve({ ok: true, json: async () => [] }) as unknown as Response


### PR DESCRIPTION
## Summary
- import `vi` from `vitest` in `setupTests.ts`

## Prompt
fix this bug

## Test Output
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> frontend@0.0.0 lint
> eslint .

Oops! Something went wrong! :(

ESLint: 9.27.0

Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js' imported from /workspace/codex-poc/frontend/eslint.config.js
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:256:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    at moduleResolve (node:internal/modules/esm/resolve:854:18)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:780:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:704:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:687:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:305:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:137:49)
```
```
npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.

> frontend@0.0.0 test
> vitest

sh: 1: vitest: not found
```


------
https://chatgpt.com/codex/tasks/task_e_68479ef41bc8832b91586970ba96e5b0