### PR TITLE
Fix fetch mock type

### DIFF
--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import { vi } from 'vitest'
 
-globalThis.fetch = vi.fn(() =>
-  Promise.resolve({ ok: true, json: async () => [] }) as unknown as Response
-)
+globalThis.fetch = vi.fn<
+  (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+>(async () => ({ ok: true, json: async () => [] } as Response))


### PR DESCRIPTION
## Summary
- update fetch mock typing to match global fetch

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847a009d074832ba9b2b80cc09015ba